### PR TITLE
Updated findIndex to indexOf due to new version

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export { concat, findIndex } from "https://deno.land/std/bytes/mod.ts";
+export { concat, indexOf } from "https://deno.land/std@0.83.0/bytes/mod.ts";


### PR DESCRIPTION
In the new version of the dependencies the name has changed. Also I changed the url of the source to the actual version, so if it change in the future the changes won't affect your code like with me with my opened issue.